### PR TITLE
restructure character validity check to be more readable and correct

### DIFF
--- a/uuidkey.go
+++ b/uuidkey.go
@@ -66,27 +66,42 @@ func Parse(key string) (Key, error) {
 //   - 38QARV0-1ET0G6Z-2CJD9VA2ZZAR0X (missing hyphen)
 //   - 38QARV0-1ET0G6-2CJD9VA-2ZZAR0X (part too short)
 func (k Key) IsValid() bool {
-	if len(k) != KeyLength { // check if the key is 31 characters long
+	// check if the key is the correct length
+	if len(k) != KeyLength {
 		return false
 	}
+
 	hyphenCount := 0
 	partLen := 0
+
 	for _, char := range k {
-		switch {
-		case char == '-':
-			hyphenCount++                 // collect the number of hyphens
-			if partLen != KeyPartLength { // check parts are 7 characters long
+		if char == '-' {
+			hyphenCount++ // collect the number of hyphens
+
+			// check parts are 7 characters long
+			if partLen != KeyPartLength {
 				return false
 			}
+
 			partLen = 0 // reset the part length
+
+			continue
+		}
+
 		// check if the key is uppercase
 		// check if the key contains only alphanumeric characters
-		case char < '0' || (char > '9' && char < 'A') || char > 'Z':
+		if char < '0' || (char > '9' && char < 'A') || char > 'Z' {
 			return false
-		default:
-			partLen++
 		}
+
+		// check if the key contains invalid characters (I, L, O, U)
+		if char == 'I' || char == 'L' || char == 'O' || char == 'U' {
+			return false
+		}
+
+		partLen++
 	}
+
 	// check if the key contains 3 hyphens and the last part is 7 characters long
 	return hyphenCount == KeyHyphenCount && partLen == KeyPartLength
 }

--- a/uuidkey_test.go
+++ b/uuidkey_test.go
@@ -29,6 +29,7 @@ func TestValid(t *testing.T) {
 		"38QARV0-1ET0G6Z-2CJD9VA-2ZZAR0!",  // Invalid character
 		"38QARV0-1ET0G6-2CJD9VA-2ZZAR0X",   // Part too short
 		"38QARV0-1ET0G6Z-2CJD9VAA-2ZZAR0",  // Third part too long
+		"38QARV0-LET0G6Z-2CJD9VA-2ZZAROX",  // Contains non-crockford base32 characters
 	}
 
 	for _, k := range validKeys {


### PR DESCRIPTION
- drops the 2-armed `switch` statement in favor of `if`
- adds check that the key doesn't contain non-crockford32 runes

I'd also recommend adding test coverage for the validity fail branch of `Decode()` and perhaps running a full validation instead of only checking length. It looks like it would likely panic or fail with undefined behavior as the error result from `crock32.Decode()` is disregarded on L126.